### PR TITLE
OTC-594: allign paymentPlan capitation to new batch run

### DIFF
--- a/calcrule_capitation_payment/config.py
+++ b/calcrule_capitation_payment/config.py
@@ -1,876 +1,1336 @@
 CLASS_RULE_PARAM_VALIDATION = [
-{
-   "class": "PaymentPlan",
-   "parameters": [
-      {
-         "type": "select",
-         "name": "hf_level_1",
-         "label": {
-            "en": "Level 1",
-            "fr": "Niveau 1"
-         },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "null",
-               "label": {
-                  "en": "",
-                  "fr": ""
-               }
+   {
+      "class": "PaymentPlan",
+      "parameters": [
+         {
+            "type": "select",
+            "name": "claim_type",
+            "label": {
+               "en": "claim type",
+               "fr": "Type de prestation"
             },
-            {
-               "value": "H",
-               "label": {
-                  "en": "Hospital",
-                  "fr": "Hopital"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "D",
-               "label": {
-                  "en": "Dispensary",
-                  "fr": "Dispensaire"
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "B",
+                  "label": {
+                     "en": "All",
+                     "fr": "toutes"
+                  }
+               },
+               {
+                  "value": "I",
+                  "label": {
+                     "en": "Hospital/in-patient",
+                     "fr": "Hopital"
+                  }
+               },
+               {
+                  "value": "O",
+                  "label": {
+                     "en": "None-Hospital/out-patient",
+                     "fr": "Hors hopitaux"
+                  }
                }
+            ]
+         },
+         {
+            "type": "select",
+            "name": "hf_level_1",
+            "label": {
+               "en": "Level 1",
+               "fr": "Niveau 1"
             },
-            {
-               "value": "C",
-               "label": {
-                  "en": "Health center",
-                  "fr": "Centre de santé"
-               }
-            }
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_sublevel_1",
-         "label": {
-            "en": "Sublevel 1",
-            "fr": "Sublevel 1"
-         },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "null",
-               "label": {
-                  "en": "",
-                  "fr": ""
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "D",
-               "label": {
-                  "en": "District",
-                  "fr": "District"
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "null",
+                  "label": {
+                     "en": "",
+                     "fr": ""
+                  }
+               },
+               {
+                  "value": "H",
+                  "label": {
+                     "en": "Hospital",
+                     "fr": "Hopital"
+                  }
+               },
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "Dispensary",
+                     "fr": "Dispensaire"
+                  }
+               },
+               {
+                  "value": "C",
+                  "label": {
+                     "en": "Health center",
+                     "fr": "Centre de santé"
+                  }
                }
+            ],
+            "default": "null"
+         },
+         {
+            "type": "select",
+            "name": "hf_sublevel_1",
+            "label": {
+               "en": "Sublevel 1",
+               "fr": "Sublevel 1"
             },
-            {
-               "value": "R",
-               "label": {
-                  "en": "Region",
-                  "fr": "Region"
-               }
-            }
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_level_2",
-         "label": {
-            "en": "Level 2",
-            "fr": "Niveau 2"
-         },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "null",
-               "label": {
-                  "en": "",
-                  "fr": ""
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "H",
-               "label": {
-                  "en": "Hospital",
-                  "fr": "Hopital"
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "null",
+                  "label": {
+                     "en": "",
+                     "fr": ""
+                  }
+               },
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "District",
+                     "fr": "District"
+                  }
+               },
+               {
+                  "value": "R",
+                  "label": {
+                     "en": "Region",
+                     "fr": "Region"
+                  }
                }
+            ],
+            "default": "null"
+         },
+         {
+            "type": "select",
+            "name": "hf_level_2",
+            "label": {
+               "en": "Level 2",
+               "fr": "Niveau 2"
             },
-            {
-               "value": "D",
-               "label": {
-                  "en": "Dispensary",
-                  "fr": "Dispensaire"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "C",
-               "label": {
-                  "en": "Health center",
-                  "fr": "Centre de santé"
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "null",
+                  "label": {
+                     "en": "",
+                     "fr": ""
+                  }
+               },
+               {
+                  "value": "H",
+                  "label": {
+                     "en": "Hospital",
+                     "fr": "Hopital"
+                  }
+               },
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "Dispensary",
+                     "fr": "Dispensaire"
+                  }
+               },
+               {
+                  "value": "C",
+                  "label": {
+                     "en": "Health center",
+                     "fr": "Centre de santé"
+                  }
                }
-            }
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_sublevel_2",
-         "label": {
-            "en": "Sublevel 2",
-            "fr": "Sublevel 2"
+            ],
+            "default": "null"
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "null",
-               "label": {
-                  "en": "",
-                  "fr": ""
-               }
+         {
+            "type": "select",
+            "name": "hf_sublevel_2",
+            "label": {
+               "en": "Sublevel 2",
+               "fr": "Sublevel 2"
             },
-            {
-               "value": "D",
-               "label": {
-                  "en": "District",
-                  "fr": "District"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "R",
-               "label": {
-                  "en": "Region",
-                  "fr": "Region"
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "null",
+                  "label": {
+                     "en": "",
+                     "fr": ""
+                  }
+               },
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "District",
+                     "fr": "District"
+                  }
+               },
+               {
+                  "value": "R",
+                  "label": {
+                     "en": "Region",
+                     "fr": "Region"
+                  }
                }
-            }
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_level_3",
-         "label": {
-            "en": "Level 3",
-            "fr": "Niveau 3"
+            ],
+            "default": "null"
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "null",
-               "label": {
-                  "en": "",
-                  "fr": ""
-               }
+         {
+            "type": "select",
+            "name": "hf_level_3",
+            "label": {
+               "en": "Level 3",
+               "fr": "Niveau 3"
             },
-            {
-               "value": "H",
-               "label": {
-                  "en": "Hospital",
-                  "fr": "Hopital"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "D",
-               "label": {
-                  "en": "Dispensary",
-                  "fr": "Dispensaire"
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "null",
+                  "label": {
+                     "en": "",
+                     "fr": ""
+                  }
+               },
+               {
+                  "value": "H",
+                  "label": {
+                     "en": "Hospital",
+                     "fr": "Hopital"
+                  }
+               },
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "Dispensary",
+                     "fr": "Dispensaire"
+                  }
+               },
+               {
+                  "value": "C",
+                  "label": {
+                     "en": "Health center",
+                     "fr": "Centre de santé"
+                  }
                }
+            ],
+            "default": "null"
+         },
+         {
+            "type": "select",
+            "name": "hf_sublevel_3",
+            "label": {
+               "en": "Sublevel 3",
+               "fr": "Sublevel 3"
             },
-            {
-               "value": "C",
-               "label": {
-                  "en": "Health center",
-                  "fr": "Centre de santé"
-               }
-            }
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_sublevel_3",
-         "label": {
-            "en": "Sublevel 3",
-            "fr": "Sublevel 3"
-         },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "null",
-               "label": {
-                  "en": "",
-                  "fr": ""
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "D",
-               "label": {
-                  "en": "District",
-                  "fr": "District"
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "null",
+                  "label": {
+                     "en": "",
+                     "fr": ""
+                  }
+               },
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "District",
+                     "fr": "District"
+                  }
+               },
+               {
+                  "value": "R",
+                  "label": {
+                     "en": "Region",
+                     "fr": "Region"
+                  }
                }
+            ],
+            "default": "null"
+         },
+         {
+            "type": "select",
+            "name": "hf_level_4",
+            "label": {
+               "en": "Level 4",
+               "fr": "Niveau 4"
             },
-            {
-               "value": "R",
-               "label": {
-                  "en": "Region",
-                  "fr": "Region"
-               }
-            }
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_level_4",
-         "label": {
-            "en": "Level 4",
-            "fr": "Niveau 4"
-         },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "null",
-               "label": {
-                  "en": "",
-                  "fr": ""
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "H",
-               "label": {
-                  "en": "Hospital",
-                  "fr": "Hopital"
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "null",
+                  "label": {
+                     "en": "",
+                     "fr": ""
+                  }
+               },
+               {
+                  "value": "H",
+                  "label": {
+                     "en": "Hospital",
+                     "fr": "Hopital"
+                  }
+               },
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "Dispensary",
+                     "fr": "Dispensaire"
+                  }
+               },
+               {
+                  "value": "C",
+                  "label": {
+                     "en": "Health center",
+                     "fr": "Centre de santé"
+                  }
                }
+            ],
+            "default": "null"
+         },
+         {
+            "type": "select",
+            "name": "hf_sublevel_4",
+            "label": {
+               "en": "Sublevel 4",
+               "fr": "Sublevel 4"
             },
-            {
-               "value": "D",
-               "label": {
-                  "en": "Dispensary",
-                  "fr": "Dispensaire"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "C",
-               "label": {
-                  "en": "Health center",
-                  "fr": "Centre de santé"
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "null",
+                  "label": {
+                     "en": "",
+                     "fr": ""
+                  }
+               },
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "District",
+                     "fr": "District"
+                  }
+               },
+               {
+                  "value": "R",
+                  "label": {
+                     "en": "Region",
+                     "fr": "Region"
+                  }
                }
-            }
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_sublevel_4",
-         "label": {
-            "en": "Sublevel 4",
-            "fr": "Sublevel 4"
+            ],
+            "default": "null"
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "null",
-               "label": {
-                  "en": "",
-                  "fr": ""
-               }
+         {
+            "type": "number",
+            "name": "share_contribution",
+            "label": {
+               "en": "Share Contribution",
+               "fr": "Share Contribution"
             },
-            {
-               "value": "D",
-               "label": {
-                  "en": "District",
-                  "fr": "District"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "R",
-               "label": {
-                  "en": "Region",
-                  "fr": "Region"
-               }
-            }
-         ],
-         "default": "null"
-      },
-      {
-         "type": "number",
-         "name": "share_contribution",
-         "label": {
-            "en": "Share Contribution",
-            "fr": "Share Contribution"
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      },
-      {
-         "type": "number",
-         "name": "weight_population",
-         "label": {
-            "en": "Weight Population",
-            "fr": "Weight Population"
-         },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      },
-      {
-         "type": "number",
-         "name": "weight_number_families",
-         "label": {
-            "en": "Weight Number Families",
-            "fr": "Weight Number Families"
-         },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      },
-      {
-         "type": "number",
-         "name": "weight_insured_population",
-         "label": {
-            "en": "Weight Number Population",
-            "fr": "Weight Number Population"
-         },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      },
-      {
-         "type": "number",
-         "name": "weight_number_insured_families",
-         "label": {
-            "en": "Weight Number Insured Families",
-            "fr": "Weight Number Insured Families"
-         },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      },
-      {
-         "type": "number",
-         "name": "weight_number_visits",
-         "label": {
-            "en": "Weight Number Visits",
-            "fr": "Weight Number Visits"
-         },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      },
-      {
-         "type": "number",
-         "name": "weight_adjusted_amount",
-         "label": {
-            "en": "Weight Adjusted Amount",
-            "fr": "Weight Adjusted Amount"
-         },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      }
-   ]
-},
-{
-   "class": "Product",
-   "parameters": [
-      {
-         "type": "select",
-         "name": "hf_level_1",
-         "label": {
-            "en": "Level 1",
-            "fr": "Niveau 1"
-         },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "H",
-               "label": {
-                  "en": "Hospital",
-                  "fr": "Hopital"
-               }
+         {
+            "type": "number",
+            "name": "weight_population",
+            "label": {
+               "en": "Weight Population",
+               "fr": "Weight Population"
             },
-            {
-               "value": "D",
-               "label": {
-                  "en": "Dispensary",
-                  "fr": "Dispensaire"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "C",
-               "label": {
-                  "en": "Health center",
-                  "fr": "Centre de santé"
-               }
-            }
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_sublevel_1",
-         "label": {
-            "en": "Sublevel 1",
-            "fr": "Sublevel 1"
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "D",
-               "label": {
-                  "en": "District",
-                  "fr": "District"
-               }
+         {
+            "type": "number",
+            "name": "weight_number_families",
+            "label": {
+               "en": "Weight Number Families",
+               "fr": "Weight Number Families"
             },
-            {
-               "value": "R",
-               "label": {
-                  "en": "Region",
-                  "fr": "Region"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_level_2",
-         "label": {
-            "en": "Level 2",
-            "fr": "Niveau 2"
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "H",
-               "label": {
-                  "en": "Hospital",
-                  "fr": "Hopital"
-               }
+         {
+            "type": "number",
+            "name": "weight_insured_population",
+            "label": {
+               "en": "Weight Number Population",
+               "fr": "Weight Number Population"
             },
-            {
-               "value": "D",
-               "label": {
-                  "en": "Dispensary",
-                  "fr": "Dispensaire"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "C",
-               "label": {
-                  "en": "Health center",
-                  "fr": "Centre de santé"
-               }
-            }
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_sublevel_2",
-         "label": {
-            "en": "Sublevel 2",
-            "fr": "Sublevel 2"
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "D",
-               "label": {
-                  "en": "District",
-                  "fr": "District"
-               }
+         {
+            "type": "number",
+            "name": "weight_number_insured_families",
+            "label": {
+               "en": "Weight Number Insured Families",
+               "fr": "Weight Number Insured Families"
             },
-            {
-               "value": "R",
-               "label": {
-                  "en": "Region",
-                  "fr": "Region"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_level_3",
-         "label": {
-            "en": "Level 3",
-            "fr": "Niveau 3"
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "H",
-               "label": {
-                  "en": "Hospital",
-                  "fr": "Hopital"
-               }
+         {
+            "type": "number",
+            "name": "weight_number_visits",
+            "label": {
+               "en": "Weight Number Visits",
+               "fr": "Weight Number Visits"
             },
-            {
-               "value": "D",
-               "label": {
-                  "en": "Dispensary",
-                  "fr": "Dispensaire"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "C",
-               "label": {
-                  "en": "Health center",
-                  "fr": "Centre de santé"
-               }
-            }
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_sublevel_3",
-         "label": {
-            "en": "Sublevel 3",
-            "fr": "Sublevel 3"
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "D",
-               "label": {
-                  "en": "District",
-                  "fr": "District"
-               }
+         {
+            "type": "number",
+            "name": "weight_adjusted_amount",
+            "label": {
+               "en": "Weight Adjusted Amount",
+               "fr": "Weight Adjusted Amount"
             },
-            {
-               "value": "R",
-               "label": {
-                  "en": "Region",
-                  "fr": "Region"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_level_4",
-         "label": {
-            "en": "Level 4",
-            "fr": "Niveau 4"
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "H",
-               "label": {
-                  "en": "Hospital",
-                  "fr": "Hopital"
-               }
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_1",
+            "label": {
+               "en": "distribution 1",
+               "fr": "distribution 1"
             },
-            {
-               "value": "D",
-               "label": {
-                  "en": "Dispensary",
-                  "fr": "Dispensaire"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-            {
-               "value": "C",
-               "label": {
-                  "en": "Health center",
-                  "fr": "Centre de santé"
-               }
-            }
-         ],
-         "default": "null"
-      },
-      {
-         "type": "select",
-         "name": "hf_sublevel_4",
-         "label": {
-            "en": "Sublevel 4",
-            "fr": "Sublevel 4"
+            "relevance": "MOD(1, OBJECT.periodicity) = 0"
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
-         },
-         "relevance": "True",
-         "optionSet": [
-            {
-               "value": "D",
-               "label": {
-                  "en": "District",
-                  "fr": "District"
-               }
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_2",
+            "label": {
+               "en": "distribution 2",
+               "fr": "distribution 2"
             },
-            {
-               "value": "R",
-               "label": {
-                  "en": "Region",
-                  "fr": "Region"
-               }
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
             },
-         ],
-         "default": "null"
-      },
-      {
-         "type": "number",
-         "name": "share_contribution",
-         "label": {
-            "en": "Share Contribution",
-            "fr": "Share Contribution"
+            "relevance": "MOD(2, OBJECT.periodicity) = 0"
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_3",
+            "label": {
+               "en": "distribution 3",
+               "fr": "distribution 3"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(3, OBJECT.periodicity) = 0"
          },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      },
-      {
-         "type": "number",
-         "name": "weight_population",
-         "label": {
-            "en": "Weight Population",
-            "fr": "Weight Population"
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_4",
+            "label": {
+               "en": "distribution 4",
+               "fr": "distribution 4"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": " MOD(4, OBJECT.periodicity) = 0"
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_5",
+            "label": {
+               "en": "distribution 5",
+               "fr": "distribution 5"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(5, OBJECT.periodicity) = 0"
          },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      },
-      {
-         "type": "number",
-         "name": "weight_number_families",
-         "label": {
-            "en": "Weight Number Families",
-            "fr": "Weight Number Families"
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_6",
+            "label": {
+               "en": "distribution 6",
+               "fr": "distribution 6"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(6, OBJECT.periodicity) = 0"
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_7",
+            "label": {
+               "en": "distribution 7",
+               "fr": "distribution 7"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(7, OBJECT.periodicity) = 0"
          },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      },
-      {
-         "type": "number",
-         "name": "weight_insured_population",
-         "label": {
-            "en": "Weight Number Population",
-            "fr": "Weight Number Population"
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_8",
+            "label": {
+               "en": "distribution 8",
+               "fr": "distribution 8"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(8, OBJECT.periodicity) = 0"
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_9",
+            "label": {
+               "en": "distribution 9",
+               "fr": "distribution 9"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(9, OBJECT.periodicity) = 0"
          },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      },
-      {
-         "type": "number",
-         "name": "weight_number_insured_families",
-         "label": {
-            "en": "Weight Number Insured Families",
-            "fr": "Weight Number Insured Families"
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_10",
+            "label": {
+               "en": "distribution 10",
+               "fr": "distribution 10"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(10, OBJECT.periodicity) = 0"
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_11",
+            "label": {
+               "en": "distribution 11",
+               "fr": "distribution 11"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(11, OBJECT.periodicity) = 0"
          },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      },
-      {
-         "type": "number",
-         "name": "weight_number_visits",
-         "label": {
-            "en": "Weight Number Visits",
-            "fr": "Weight Number Visits"
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_12",
+            "label": {
+               "en": "distribution 12",
+               "fr": "distribution 12"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(12, OBJECT.periodicity) = 0"
+         }
+      ]
+   },
+   {
+      "class": "Product",
+      "parameters": [
+         {
+            "type": "select",
+            "name": "claim_type",
+            "label": {
+               "en": "claim type",
+               "fr": "Type de prestation"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "B",
+                  "label": {
+                     "en": "All",
+                     "fr": "toutes"
+                  }
+               },
+               {
+                  "value": "I",
+                  "label": {
+                     "en": "Hospital/in-patient",
+                     "fr": "Hopital"
+                  }
+               },
+               {
+                  "value": "O",
+                  "label": {
+                     "en": "None-Hospital/out-patient",
+                     "fr": "Hors hopitaux"
+                  }
+               }
+            ]
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
+         {
+            "type": "select",
+            "name": "hf_level_1",
+            "label": {
+               "en": "Level 1",
+               "fr": "Niveau 1"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "H",
+                  "label": {
+                     "en": "Hospital",
+                     "fr": "Hopital"
+                  }
+               },
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "Dispensary",
+                     "fr": "Dispensaire"
+                  }
+               },
+               {
+                  "value": "C",
+                  "label": {
+                     "en": "Health center",
+                     "fr": "Centre de santé"
+                  }
+               }
+            ],
+            "default": "null"
          },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      },
-      {
-         "type": "number",
-         "name": "weight_adjusted_amount",
-         "label": {
-            "en": "Weight Adjusted Amount",
-            "fr": "Weight Adjusted Amount"
+         {
+            "type": "select",
+            "name": "hf_sublevel_1",
+            "label": {
+               "en": "Sublevel 1",
+               "fr": "Sublevel 1"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "District",
+                     "fr": "District"
+                  }
+               },
+               {
+                  "value": "R",
+                  "label": {
+                     "en": "Region",
+                     "fr": "Region"
+                  }
+               }
+            ],
+            "default": "null"
          },
-         "rights": {
-            "read": "121001",
-            "write": "121002",
-            "update": "121003",
-            "replace": "121006"
+         {
+            "type": "select",
+            "name": "hf_level_2",
+            "label": {
+               "en": "Level 2",
+               "fr": "Niveau 2"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "H",
+                  "label": {
+                     "en": "Hospital",
+                     "fr": "Hopital"
+                  }
+               },
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "Dispensary",
+                     "fr": "Dispensaire"
+                  }
+               },
+               {
+                  "value": "C",
+                  "label": {
+                     "en": "Health center",
+                     "fr": "Centre de santé"
+                  }
+               }
+            ],
+            "default": "null"
          },
-         "relevance": "True",
-         "condition": "INPUT<100",
-         "default": ""
-      }
-   ]
-}
+         {
+            "type": "select",
+            "name": "hf_sublevel_2",
+            "label": {
+               "en": "Sublevel 2",
+               "fr": "Sublevel 2"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "District",
+                     "fr": "District"
+                  }
+               },
+               {
+                  "value": "R",
+                  "label": {
+                     "en": "Region",
+                     "fr": "Region"
+                  }
+               }
+            ],
+            "default": "null"
+         },
+         {
+            "type": "select",
+            "name": "hf_level_3",
+            "label": {
+               "en": "Level 3",
+               "fr": "Niveau 3"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "H",
+                  "label": {
+                     "en": "Hospital",
+                     "fr": "Hopital"
+                  }
+               },
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "Dispensary",
+                     "fr": "Dispensaire"
+                  }
+               },
+               {
+                  "value": "C",
+                  "label": {
+                     "en": "Health center",
+                     "fr": "Centre de santé"
+                  }
+               }
+            ],
+            "default": "null"
+         },
+         {
+            "type": "select",
+            "name": "hf_sublevel_3",
+            "label": {
+               "en": "Sublevel 3",
+               "fr": "Sublevel 3"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "District",
+                     "fr": "District"
+                  }
+               },
+               {
+                  "value": "R",
+                  "label": {
+                     "en": "Region",
+                     "fr": "Region"
+                  }
+               }
+            ],
+            "default": "null"
+         },
+         {
+            "type": "select",
+            "name": "hf_level_4",
+            "label": {
+               "en": "Level 4",
+               "fr": "Niveau 4"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "H",
+                  "label": {
+                     "en": "Hospital",
+                     "fr": "Hopital"
+                  }
+               },
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "Dispensary",
+                     "fr": "Dispensaire"
+                  }
+               },
+               {
+                  "value": "C",
+                  "label": {
+                     "en": "Health center",
+                     "fr": "Centre de santé"
+                  }
+               }
+            ],
+            "default": "null"
+         },
+         {
+            "type": "select",
+            "name": "hf_sublevel_4",
+            "label": {
+               "en": "Sublevel 4",
+               "fr": "Sublevel 4"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "optionSet": [
+               {
+                  "value": "D",
+                  "label": {
+                     "en": "District",
+                     "fr": "District"
+                  }
+               },
+               {
+                  "value": "R",
+                  "label": {
+                     "en": "Region",
+                     "fr": "Region"
+                  }
+               }
+            ],
+            "default": "null"
+         },
+         {
+            "type": "number",
+            "name": "share_contribution",
+            "label": {
+               "en": "Share Contribution",
+               "fr": "Share Contribution"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
+         },
+         {
+            "type": "number",
+            "name": "weight_population",
+            "label": {
+               "en": "Weight Population",
+               "fr": "Weight Population"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
+         },
+         {
+            "type": "number",
+            "name": "weight_number_families",
+            "label": {
+               "en": "Weight Number Families",
+               "fr": "Weight Number Families"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
+         },
+         {
+            "type": "number",
+            "name": "weight_insured_population",
+            "label": {
+               "en": "Weight Number Population",
+               "fr": "Weight Number Population"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
+         },
+         {
+            "type": "number",
+            "name": "weight_number_insured_families",
+            "label": {
+               "en": "Weight Number Insured Families",
+               "fr": "Weight Number Insured Families"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
+         },
+         {
+            "type": "number",
+            "name": "weight_number_visits",
+            "label": {
+               "en": "Weight Number Visits",
+               "fr": "Weight Number Visits"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
+         },
+         {
+            "type": "number",
+            "name": "weight_adjusted_amount",
+            "label": {
+               "en": "Weight Adjusted Amount",
+               "fr": "Weight Adjusted Amount"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "True",
+            "condition": "INPUT<100",
+            "default": ""
+         },
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_1",
+            "label": {
+               "en": "distribution 1",
+               "fr": "distribution 1"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(1, OBJECT.periodicity) = 0"
+         },
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_2",
+            "label": {
+               "en": "distribution 2",
+               "fr": "distribution 2"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(2, OBJECT.periodicity) = 0"
+         },
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_3",
+            "label": {
+               "en": "distribution 3",
+               "fr": "distribution 3"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(3, OBJECT.periodicity) = 0"
+         },
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_4",
+            "label": {
+               "en": "distribution 4",
+               "fr": "distribution 4"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": " MOD(4, OBJECT.periodicity) = 0"
+         },
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_5",
+            "label": {
+               "en": "distribution 5",
+               "fr": "distribution 5"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(5, OBJECT.periodicity) = 0"
+         },
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_6",
+            "label": {
+               "en": "distribution 6",
+               "fr": "distribution 6"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(6, OBJECT.periodicity) = 0"
+         },
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_7",
+            "label": {
+               "en": "distribution 7",
+               "fr": "distribution 7"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(7, OBJECT.periodicity) = 0"
+         },
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_8",
+            "label": {
+               "en": "distribution 8",
+               "fr": "distribution 8"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(8, OBJECT.periodicity) = 0"
+         },
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_9",
+            "label": {
+               "en": "distribution 9",
+               "fr": "distribution 9"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(9, OBJECT.periodicity) = 0"
+         },
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_10",
+            "label": {
+               "en": "distribution 10",
+               "fr": "distribution 10"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(10, OBJECT.periodicity) = 0"
+         },
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_11",
+            "label": {
+               "en": "distribution 11",
+               "fr": "distribution 11"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(11, OBJECT.periodicity) = 0"
+         },
+         {
+            "type": "number",
+            "default": "0",
+            "name": "distr_12",
+            "label": {
+               "en": "distribution 12",
+               "fr": "distribution 12"
+            },
+            "rights": {
+               "read": "121001",
+               "write": "121002",
+               "update": "121003",
+               "replace": "121006"
+            },
+            "relevance": "MOD(12, OBJECT.periodicity) = 0"
+         }
+      ]
+   }
 ]
 
 
@@ -884,3 +1344,24 @@ DESCRIPTION_CONTRIBUTION_VALUATION = F'' \
     F'This calculation will, for the selected level and product,' \
     F' calculate how much the insurance need to' \
     F' the HF for the capitation financing'
+
+
+CONTEXTS = ["BatchValuate", "BatchPayment", "IndividualPayment", "IndividualValuation"]
+
+
+INTEGER_PARAMETERS = [
+    "share_contribution", "weight_population", "weight_number_families", "weight_insured_population",
+    "weight_number_insured_families", "weight_number_visits", "weight_adjusted_amount",
+    "distr_1", "distr_2", "distr_3", "distr_4", "distr_5", "distr_6",
+    "distr_7", "distr_8", "distr_9", "distr_10", "distr_11", "distr_12",
+]
+
+
+NONE_INTEGER_PARAMETERS = ['hf_level_1',
+                           'hf_sublevel_1',
+                           'hf_level_2',
+                           'hf_sublevel_2',
+                           'hf_level_3',
+                           'hf_sublevel_3',
+                           'hf_level_4',
+                           'hf_sublevel_4']

--- a/calcrule_capitation_payment/legacy.py
+++ b/calcrule_capitation_payment/legacy.py
@@ -1,0 +1,125 @@
+import logging
+
+from django.db import connection
+from django.db.models import Value
+from django.db.models.functions import Coalesce
+
+from claim.models import (
+    ClaimItem,
+    Claim,
+    ClaimService
+)
+from location.models import Location
+
+logger = logging.getLogger(__name__)
+
+
+#@deprecated
+def capitation_report_data_for_submit(audit_user_id, location_id, period, year):
+    # moved from claim_batch module
+    capitation_payment_products = []
+    for svc_item in [ClaimItem, ClaimService]:
+        capitation_payment_products.extend(
+            svc_item.objects
+                    .filter(claim__status=Claim.STATUS_VALUATED)
+                    .filter(claim__validity_to__isnull=True)
+                    .filter(validity_to__isnull=True)
+                    .filter(status=svc_item.STATUS_PASSED)
+                    .annotate(prod_location=Coalesce("product__location_id", Value(-1)))
+                    .filter(prod_location=location_id if location_id else -1)
+                    .values('product_id')
+                    .distinct()
+        )
+
+    region_id, district_id, region_code, district_code = get_capitation_region_and_district(location_id)
+    for product in set(map(lambda x: x['product_id'], capitation_payment_products)):
+        params = {
+            'region_id': region_id,
+            'district_id': district_id,
+            'prod_id': product,
+            'year': year,
+            'month': period,
+        }
+        is_report_data_available = get_commision_payment_report_data(params)
+        if not is_report_data_available:
+            process_capitation_payment_data(params)
+        else:
+            logger.debug(F"Capitation payment data for {params} already exists")
+
+
+#@deprecated
+def get_capitation_region_and_district(location_id):
+    if not location_id:
+        return None, None, None, None
+    location = Location.objects.get(id=location_id)
+
+    region_id = None
+    region_code = None
+    district_id = None
+    district_code = None
+
+    if location.type == 'D':
+        district_id = location_id
+        district_code = location.code
+        region_id = location.parent.id
+        region_code = location.parent.code
+    elif location.type == 'R':
+        region_id = location.id
+        region_code = location.code
+    return region_id, district_id, region_code, district_code
+
+
+#@deprecated
+def process_capitation_payment_data(params):
+    with connection.cursor() as cur:
+        # HFLevel based on
+        # https://github.com/openimis/web_app_vb/blob/2492c20d8959e39775a2dd4013d2fda8feffd01c/IMIS_BL/HealthFacilityBL.vb#L77
+        _execute_capitation_payment_procedure(cur, 'uspCreateCapitationPaymentReportData', params)
+
+
+#@deprecated
+def get_commision_payment_report_data(params):
+    with connection.cursor() as cur:
+        # HFLevel based on
+        # https://github.com/openimis/web_app_vb/blob/2492c20d8959e39775a2dd4013d2fda8feffd01c/IMIS_BL/HealthFacilityBL.vb#L77
+        _execute_capitation_payment_procedure(cur, 'uspSSRSRetrieveCapitationPaymentReportData', params)
+
+        # stored proc outputs several results,
+        # we are only interested in the last one
+        next = True
+        data = None
+        while next:
+            try:
+                data = cur.fetchall()
+            except Exception as e:
+                pass
+            finally:
+                next = cur.nextset()
+    return data
+
+
+#@deprecated
+def _execute_capitation_payment_procedure(cursor, procedure, params):
+    sql = F"""\
+                DECLARE @HF AS xAttributeV;
+
+                INSERT INTO @HF (Code, Name) VALUES ('D', 'Dispensary');
+                INSERT INTO @HF (Code, Name) VALUES ('C', 'Health Centre');
+                INSERT INTO @HF (Code, Name) VALUES ('H', 'Hospital');
+
+                EXEC [dbo].[{procedure}]
+                    @RegionId = %s,
+                    @DistrictId = %s,
+                    @ProdId = %s,
+                    @Year = %s,
+                    @Month = %s,	
+                    @HFLevel = @HF
+            """
+
+    cursor.execute(sql, (
+        params.get('region_id', None),
+        params.get('district_id', None),
+        params.get('prod_id', 0),
+        params.get('year', 0),
+        params.get('month', 0),
+    ))

--- a/calcrule_capitation_payment/legacy.py
+++ b/calcrule_capitation_payment/legacy.py
@@ -1,53 +1,11 @@
 import logging
 
-from django.db import connection
-from django.db.models import Value
-from django.db.models.functions import Coalesce
-
-from claim.models import (
-    ClaimItem,
-    Claim,
-    ClaimService
-)
 from location.models import Location
+
 
 logger = logging.getLogger(__name__)
 
 
-#@deprecated
-def capitation_report_data_for_submit(audit_user_id, location_id, period, year):
-    # moved from claim_batch module
-    capitation_payment_products = []
-    for svc_item in [ClaimItem, ClaimService]:
-        capitation_payment_products.extend(
-            svc_item.objects
-                    .filter(claim__status=Claim.STATUS_VALUATED)
-                    .filter(claim__validity_to__isnull=True)
-                    .filter(validity_to__isnull=True)
-                    .filter(status=svc_item.STATUS_PASSED)
-                    .annotate(prod_location=Coalesce("product__location_id", Value(-1)))
-                    .filter(prod_location=location_id if location_id else -1)
-                    .values('product_id')
-                    .distinct()
-        )
-
-    region_id, district_id, region_code, district_code = get_capitation_region_and_district(location_id)
-    for product in set(map(lambda x: x['product_id'], capitation_payment_products)):
-        params = {
-            'region_id': region_id,
-            'district_id': district_id,
-            'prod_id': product,
-            'year': year,
-            'month': period,
-        }
-        is_report_data_available = get_commision_payment_report_data(params)
-        if not is_report_data_available:
-            process_capitation_payment_data(params)
-        else:
-            logger.debug(F"Capitation payment data for {params} already exists")
-
-
-#@deprecated
 def get_capitation_region_and_district(location_id):
     if not location_id:
         return None, None, None, None
@@ -67,59 +25,3 @@ def get_capitation_region_and_district(location_id):
         region_id = location.id
         region_code = location.code
     return region_id, district_id, region_code, district_code
-
-
-#@deprecated
-def process_capitation_payment_data(params):
-    with connection.cursor() as cur:
-        # HFLevel based on
-        # https://github.com/openimis/web_app_vb/blob/2492c20d8959e39775a2dd4013d2fda8feffd01c/IMIS_BL/HealthFacilityBL.vb#L77
-        _execute_capitation_payment_procedure(cur, 'uspCreateCapitationPaymentReportData', params)
-
-
-#@deprecated
-def get_commision_payment_report_data(params):
-    with connection.cursor() as cur:
-        # HFLevel based on
-        # https://github.com/openimis/web_app_vb/blob/2492c20d8959e39775a2dd4013d2fda8feffd01c/IMIS_BL/HealthFacilityBL.vb#L77
-        _execute_capitation_payment_procedure(cur, 'uspSSRSRetrieveCapitationPaymentReportData', params)
-
-        # stored proc outputs several results,
-        # we are only interested in the last one
-        next = True
-        data = None
-        while next:
-            try:
-                data = cur.fetchall()
-            except Exception as e:
-                pass
-            finally:
-                next = cur.nextset()
-    return data
-
-
-#@deprecated
-def _execute_capitation_payment_procedure(cursor, procedure, params):
-    sql = F"""\
-                DECLARE @HF AS xAttributeV;
-
-                INSERT INTO @HF (Code, Name) VALUES ('D', 'Dispensary');
-                INSERT INTO @HF (Code, Name) VALUES ('C', 'Health Centre');
-                INSERT INTO @HF (Code, Name) VALUES ('H', 'Hospital');
-
-                EXEC [dbo].[{procedure}]
-                    @RegionId = %s,
-                    @DistrictId = %s,
-                    @ProdId = %s,
-                    @Year = %s,
-                    @Month = %s,	
-                    @HFLevel = @HF
-            """
-
-    cursor.execute(sql, (
-        params.get('region_id', None),
-        params.get('district_id', None),
-        params.get('prod_id', 0),
-        params.get('year', 0),
-        params.get('month', 0),
-    ))

--- a/calcrule_capitation_payment/tests.py
+++ b/calcrule_capitation_payment/tests.py
@@ -1,3 +1,200 @@
-from django.test import TestCase
+import calendar
+import datetime
+import decimal
 
-# Create your tests here.
+from claim.gql_mutations import validate_and_process_dedrem_claim
+from claim.models import ClaimDedRem, Claim
+from claim.test_helpers import (
+    create_test_claim,
+    create_test_claimservice,
+    create_test_claimitem,
+    delete_claim_with_itemsvc_dedrem_and_history,
+)
+from claim_batch.services import do_process_batch
+from contribution.test_helpers import create_test_payer, create_test_premium
+from contribution_plan.models import PaymentPlan
+from contribution_plan.tests.helpers import create_test_payment_plan
+from core.services import create_or_update_interactive_user, create_or_update_core_user
+from django.test import TestCase
+from insuree.test_helpers import create_test_insuree
+from invoice.models import Bill
+from medical.test_helpers import create_test_service, create_test_item
+from medical_pricelist.test_helpers import (
+    add_service_to_hf_pricelist,
+    add_item_to_hf_pricelist,
+)
+from policy.test_helpers import create_test_policy
+from product.models import ProductItemOrService
+from product.test_helpers import (
+    create_test_product,
+    create_test_product_service,
+    create_test_product_item,
+)
+
+_TEST_USER_NAME = "test_batch_run"
+_TEST_USER_PASSWORD = "test_batch_run"
+_TEST_DATA_USER = {
+    "username": _TEST_USER_NAME,
+    "last_name": _TEST_USER_NAME,
+    "password": _TEST_USER_PASSWORD,
+    "other_names": _TEST_USER_NAME,
+    "user_types": "INTERACTIVE",
+    "language": "en",
+    "roles": [1, 5, 9],
+}
+
+
+class BatchRunWithCapitationPaymentTest(TestCase):
+    def setUp(self) -> None:
+        i_user, i_user_created = create_or_update_interactive_user(
+            user_id=None, data=_TEST_DATA_USER, audit_user_id=999, connected=False)
+        user, user_created = create_or_update_core_user(
+            user_uuid=None, username=_TEST_DATA_USER["username"], i_user=i_user)
+        self.user = user
+
+    def test_simple_batch(self):
+        """
+        This test creates a claim, submits it so that it gets dedrem entries,
+        then submits a review rejecting part of it, then process the claim.
+        It should not be processed (which was ok) but the dedrem should be deleted.
+        """
+        # Given
+        insuree = create_test_insuree()
+        self.assertIsNotNone(insuree)
+        service = create_test_service("A", custom_props={"name": "test_simple_batch"})
+        item = create_test_item("A", custom_props={"name": "test_simple_batch"})
+
+        product = create_test_product(
+            "BCUL0001",
+            custom_props={
+                "name": "simplebatch",
+                "lump_sum": 10_000,
+            },
+        )
+        payment_plan = create_test_payment_plan(
+            product=product,
+            calculation="0a1b6d54-5681-4fa6-ac47-2a99c235eaa8",
+            custom_props={
+                'periodicity': 1,
+                'date_valid_from': '2019-01-01',
+                'date_valid_to': '2050-01-01',
+                'json_ext': {
+                    'calculation_rule': {
+                        'hf_level_1': 'H',
+                        'hf_sublevel_1': "null",
+                        'hf_level_2': 'D',
+                        'hf_sublevel_2': "null",
+                        'hf_level_3': 'C',
+                        'hf_sublevel_3': "null",
+                        'hf_level_4': "null",
+                        'hf_sublevel_4': "null",
+                        'distr_1': 100,
+                        'distr_2': 100,
+                        'distr_3': 100,
+                        'distr_4': 100,
+                        'distr_5': 100,
+                        'distr_6': 100,
+                        'distr_7': 100,
+                        'distr_8': 100,
+                        'distr_9': 100,
+                        'distr_10': 100,
+                        'distr_11': 100,
+                        'distr_12': 100,
+                        'claim_type': 'B',
+                        'weight_adjusted_amount': 2,
+                        "share_contribution": 1,
+                        "weight_population": 1,
+                        "weight_number_families": 1,
+                        "weight_insured_population": 1,
+                        "weight_number_insured_families": 1,
+                        "weight_number_visits": 1
+                    }
+                }
+            }
+        )
+
+        product_service = create_test_product_service(
+            product,
+            service,
+            custom_props={"price_origin": ProductItemOrService.ORIGIN_RELATIVE},
+        )
+        product_item = create_test_product_item(
+            product,
+            item,
+            custom_props={"price_origin": ProductItemOrService.ORIGIN_RELATIVE},
+        )
+        policy = create_test_policy(product, insuree, link=True)
+        payer = create_test_payer()
+        premium = create_test_premium(
+            policy_id=policy.id, custom_props={"payer_id": payer.id}
+        )
+        pricelist_detail1 = add_service_to_hf_pricelist(service)
+        pricelist_detail2 = add_item_to_hf_pricelist(item)
+
+        claim1 = create_test_claim({"insuree_id": insuree.id})
+        service1 = create_test_claimservice(
+            claim1, custom_props={"service_id": service.id, "qty_provided": 2}
+        )
+        item1 = create_test_claimitem(
+            claim1, "A", custom_props={"item_id": item.id, "qty_provided": 3}
+        )
+        errors = validate_and_process_dedrem_claim(claim1, self.user, True)
+        _, days_in_month = calendar.monthrange(claim1.validity_from.year, claim1.validity_from.month)
+        # add process stamp for claim to not use the process_stamp with now()
+        claim1.process_stamp = datetime.datetime(claim1.validity_from.year, claim1.validity_from.month,
+                                                 days_in_month - 1)
+        claim1.save()
+
+        self.assertEqual(len(errors), 0)
+        self.assertEqual(
+            claim1.status,
+            Claim.STATUS_PROCESSED,
+            "The claim has relative pricing, so should go to PROCESSED rather than VALUATED",
+        )
+        # Make sure that the dedrem was generated
+        dedrem = ClaimDedRem.objects.filter(claim=claim1).first()
+        self.assertIsNotNone(dedrem)
+        self.assertEquals(dedrem.rem_g, 500)  # 100*2 + 100*3
+        # renumerated should be Null
+        self.assertEqual(claim1.remunerated, None)
+
+        # When
+        end_date = datetime.datetime(claim1.validity_from.year, claim1.validity_from.month, days_in_month)
+        batch_run = do_process_batch(
+            self.user.id_for_audit,
+            None,
+            end_date
+        )
+
+        claim1.refresh_from_db()
+        item1.refresh_from_db()
+        service1.refresh_from_db()
+
+        self.assertEquals(claim1.status, Claim.STATUS_VALUATED)
+        self.assertNotEqual(item1.price_valuated, item1.price_adjusted)
+        self.assertNotEqual(service1.price_valuated, service1.price_adjusted)
+        # based on calculation - should be 402.31 per item and service
+        # therefore renumerated = 804.62
+        self.assertEqual(item1.price_valuated, decimal.Decimal('402.31'))
+        self.assertEqual(service1.price_valuated, decimal.Decimal('402.31'))
+        self.assertEqual(claim1.remunerated, service1.price_valuated + item1.price_valuated)
+
+        # tearDown
+        # dedrem.delete() # already done if the test passed
+        premium.delete()
+        payer.delete()
+        delete_claim_with_itemsvc_dedrem_and_history(claim1)
+        policy.insuree_policies.first().delete()
+        policy.delete()
+        product_item.delete()
+        product_service.delete()
+        pricelist_detail1.delete()
+        pricelist_detail2.delete()
+        service.delete()
+        item.delete()
+        product.relativeindex_set.all().delete()
+        product.relative_distributions.all().delete()
+        PaymentPlan.objects.filter(id=payment_plan.id).delete()
+        product.delete()
+        if batch_run is not None:
+            batch_run.delete()

--- a/calcrule_capitation_payment/tests.py
+++ b/calcrule_capitation_payment/tests.py
@@ -32,11 +32,11 @@ from product.test_helpers import (
 )
 
 _TEST_USER_NAME = "test_batch_run"
-_TEST_USER_PASSWORD = "test_batch_run"
+_TEST_USER_PWD = "test_batch_run"
 _TEST_DATA_USER = {
     "username": _TEST_USER_NAME,
     "last_name": _TEST_USER_NAME,
-    "password": _TEST_USER_PASSWORD,
+    "password": _TEST_USER_PWD,
     "other_names": _TEST_USER_NAME,
     "user_types": "INTERACTIVE",
     "language": "en",


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OTC-594

Changes:
    - used amount based on the period (distr_1…)
    - added claim_type (hospital/non-hospital)
   - adde valuation part for capitation 
   - fixed some bugs with counting sum=None after aggregations
   - moved some constant variables into config.py
   - use 'obtain_json_params' function from ContributionPlan module
   - added test to test this calcrule
   - added more additional checks in tests whether renumerated amount is correct ('BatchValuate' check)
   - moved legacy code to legacy.py file (those functions with calls to Stored Procedures)

Related PRs:
    https://github.com/openimis/openimis-be-claim_batch_py/pull/25
    https://github.com/openimis/openimis-be-contribution_plan_py/pull/39

CI will fail until changes from above PRs are merged.